### PR TITLE
DatePickerの書式変更

### DIFF
--- a/app/javascript/packs/materialize.js
+++ b/app/javascript/packs/materialize.js
@@ -20,6 +20,6 @@ $(document).ready(function(){
     },
     showClearBtn: true,
     autoClose: true,
-    format: "yyyy年mm月dd日(ddd)"
+    format: "yyyy/mm/dd"
   });
 });

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -33,8 +33,7 @@ class Event < ApplicationRecord
       end
     end
     if params[:gig_date].present?
-      gig_date = convert_gig_date_to_i(params[:gig_date])
-      query = Event.where('gig_date >= ?', "#{gig_date}")
+      query = Event.where('gig_date >= ?', "#{params[:gig_date]}")
       result = result ? result.merge(query) : query
     end
     if params[:region].present?
@@ -42,10 +41,5 @@ class Event < ApplicationRecord
       result = result ? result.merge(query) : query
     end
     result
-  end
-
-  def self.convert_gig_date_to_i(gig_date)
-    m = gig_date.match(/^(\d{4})年(\d{1,2})月(\d{1,2})日\(.\)$/)
-    gig_date = DateTime.new(m[1].to_i, m[2].to_i, m[3].to_i)
   end
 end


### PR DESCRIPTION
`format: "yyyy年mm月dd日(ddd)"`ではDB登録時にエラーとなる為、書式変更