### PR TITLE
TwitterのOAuth認証機能を追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,9 +47,10 @@ gem "materialize-sass"
 gem "material_icons"
 gem "rails-i18n"
 gem "devise"
+gem "omniauth"
+gem "omniauth-twitter"
+gem "dotenv-rails", "~> 2.1", ">= 2.1.1"
 gem "kaminari"
-# vue用の設定
-gem "foreman"
 
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,10 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.3)
-    dotenv (0.7.0)
+    dotenv (2.7.5)
+    dotenv-rails (2.7.5)
+      dotenv (= 2.7.5)
+      railties (>= 3.2, < 6.1)
     erubi (1.9.0)
     execjs (2.7.0)
     factory_bot (4.10.0)
@@ -90,11 +93,9 @@ GEM
       factory_bot (~> 4.10.0)
       railties (>= 3.0.0)
     ffi (1.11.1)
-    foreman (0.64.0)
-      dotenv (~> 0.7.0)
-      thor (>= 0.13.6)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashie (3.6.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
     jaro_winkler (1.5.3)
@@ -140,6 +141,16 @@ GEM
     nio4r (2.4.0)
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
+    oauth (0.5.4)
+    omniauth (1.9.0)
+      hashie (>= 3.4.6, < 3.7.0)
+      rack (>= 1.6.2, < 3)
+    omniauth-oauth (1.1.0)
+      oauth
+      omniauth (~> 1.0)
+    omniauth-twitter (1.4.0)
+      omniauth-oauth (~> 1.1)
+      rack
     orm_adapter (0.5.0)
     parallel (1.18.0)
     parser (2.6.5.0)
@@ -299,14 +310,16 @@ DEPENDENCIES
   capybara (>= 2.15)
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails (~> 2.1, >= 2.1.1)
   factory_bot_rails (~> 4.10.0)
-  foreman
   jbuilder (~> 2.5)
   jquery-rails
   kaminari
   listen (>= 3.0.5, < 3.2)
   material_icons
   materialize-sass
+  omniauth
+  omniauth-twitter
   pg (>= 0.18, < 2.0)
   pry-byebug
   puma (~> 3.11)

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,3 +1,0 @@
-web: bundle exec rails s
-# watcher: ./bin/webpack-watcher
-webpacker: ./bin/webpack-dev-server

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -247,9 +247,13 @@ a:hover {
   }
 }
 
+.omniauth {
+  margin-bottom: 10px;
+}
 @media only screen and (max-width: 1200px) {
   .user_form .btn,
   .user_form.btn,
+  .omniauth .btn,
   .event_form .btn,
   .searchCondition .btn {
     width: 100%;

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,6 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def twitter
-    @user = User.from_omniauth(request.env["omniauth.auth"])
+    @user = User.from_omniauth(request.env["omniauth.auth"], current_user)
 
     # 保存済みかどうか確認
     if @user.persisted?

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   def twitter
     @user = User.from_omniauth(request.env["omniauth.auth"], current_user)
 
     # 保存済みかどうか確認
     if @user.persisted?
-      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+      sign_in_and_redirect @user, event: :authentication
       set_flash_message(:notice, :success, kind: "twitter") if is_navigational_format?
     else
       session["devise.twitter_data"] = request.env["omniauth.auth"]

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,18 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  def twitter
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    # 保存済みかどうか確認
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication #this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: "twitter") if is_navigational_format?
+    else
+      session["devise.twitter_data"] = request.env["omniauth.auth"]
+      redirect_to new_user_registration_url
+    end
+  end
+
+  def failure
+    redirect_to root_path
+  end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -4,4 +4,13 @@ class Users::RegistrationsController < Devise::RegistrationsController
     hash[:uid] = User.create_unique_string
     super
   end
+
+  protected
+    def update_resource(resource, params)
+      resource.update_without_password(params)
+    end
+
+    def after_update_path_for(resource)
+      user_path(current_user.id)
+    end
 end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,10 +1,4 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  # uid=nil防止のため、ユーザー登録（deviseのcreateアクション）で使用するメソッドを上書き
-  def build_resource(hash = {})
-    hash[:uid] = User.create_unique_string
-    super
-  end
-
   protected
     def update_resource(resource, params)
       resource.update_without_password(params)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Users::RegistrationsController < Devise::RegistrationsController
   protected
     def update_resource(resource, params)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,7 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+  # uid=nil防止のため、ユーザー登録（deviseのcreateアクション）で使用するメソッドを上書き
+  def build_resource(hash = {})
+    hash[:uid] = User.create_unique_string
+    super
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,7 +9,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable
+         :recoverable, :rememberable, :validatable, :omniauthable
 
   # フォローの設定
   has_many :active_follow_relations, class_name:  "FollowRelation", foreign_key: "follower_id", dependent: :destroy
@@ -89,4 +89,21 @@ class User < ApplicationRecord
     end
     result
   end
+
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = User.dummy_email(auth)
+      user.password = Devise.friendly_token[0, 20]
+      user.name = auth.info.name
+      user.login_name = auth.info.nickname
+      user.region = auth.info.location
+      user.profile = auth.info.description
+      user.genre = "ALL"
+    end
+  end
+
+  private
+    def self.dummy_email(auth)
+      "#{auth.uid}-#{auth.provider}@example.com"
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,15 +90,24 @@ class User < ApplicationRecord
     result
   end
 
-  def self.from_omniauth(auth)
-    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
-      user.email = User.dummy_email(auth)
-      user.password = Devise.friendly_token[0, 20]
-      user.name = auth.info.name
-      user.login_name = auth.info.nickname
-      user.region = auth.info.location
-      user.profile = auth.info.description
-      user.genre = "ALL"
+  def self.from_omniauth(auth, signed_in_resource)
+    if signed_in_resource
+      signed_in_resource.update!(
+        provider: auth.provider,
+        uid: auth.uid,
+        login_name: auth.info.nickname
+      )
+      signed_in_resource
+    else
+      where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+        user.email = User.dummy_email(auth)
+        user.password = Devise.friendly_token[0, 20]
+        user.name = auth.info.name
+        user.login_name = auth.info.nickname
+        user.region = auth.info.location
+        user.profile = auth.info.description
+        user.genre = "ALL"
+      end
     end
   end
 

--- a/app/views/application/_header.html.slim
+++ b/app/views/application/_header.html.slim
@@ -17,7 +17,7 @@
               i.material-icons.left.responsive library_add
               span.responsive イベント作成
           li
-            = link_to "/users/#{current_user.id}"
+            = link_to user_path(current_user.id)
               i.material-icons.left.responsive account_circle
               span.responsive.name #{current_user.name}
           li

--- a/app/views/devise/registrations/_form.html.slim
+++ b/app/views/devise/registrations/_form.html.slim
@@ -25,3 +25,13 @@
     = f.password_field :password_confirmation, autocomplete: "new-password"
   .actions
     = f.submit :class=>"btn"
+
+.omniauth
+  - if user_signed_in?
+    - if current_user.provider.present?
+      .btn.blue.disabled
+        | TWITTERアカウント連携済み
+    - else
+      = link_to "TWITTERアカウントと連携", omniauth_authorize_path(resource_name, :twitter), class: "btn blue"
+  - else
+    = link_to t(:'devise.shared.links.sign_in_with_provider', provider: :twitter), omniauth_authorize_path(resource_name, :twitter), class: "btn blue"

--- a/app/views/devise/registrations/_form.html.slim
+++ b/app/views/devise/registrations/_form.html.slim
@@ -23,9 +23,5 @@
   .field class="#{"require" unless user_signed_in?}"
     = f.label :password_confirmation
     = f.password_field :password_confirmation, autocomplete: "new-password"
-  - if user_signed_in?
-    .field.require
-      = f.label :current_password
-      = f.password_field :current_password, autocomplete: "current-password"
   .actions
     = f.submit :class=>"btn"

--- a/app/views/devise/sessions/new.html.slim
+++ b/app/views/devise/sessions/new.html.slim
@@ -20,3 +20,6 @@
                 span = t(:'activerecord.attributes.user.remember_me')
           .actions
             = f.submit t(:'.sign_in'), class: "btn"
+        - resource_class.omniauth_providers.each do |provider|
+          .omniauth
+            = link_to t(:'devise.shared.links.sign_in_with_provider', provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), class: "btn blue"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -21,7 +21,8 @@
                   span.name = @user.name 
                   - if @user.login_name.present?
                     br
-                    span.login_name #{"@" + @user.login_name}
+                    span.login_name
+                      = link_to "@#{@user.login_name}", "https://twitter.com/#{@user.login_name}"
                 ul.genre
                   - genres(@user.genre).each do |genre|
                     li = link_to genre, search_users_path(genre: genre)

--- a/bin/server
+++ b/bin/server
@@ -1,3 +1,0 @@
-#!/bin/bash -i
-bundle install
-bundle exec foreman start -f Procfile.dev

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -260,6 +260,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+  config.omniauth :twitter, ENV["TWITTER_API_KEY"], ENV["TWITTER_SECRET_KEY"], scope: 'user,public_repo'
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -260,7 +260,7 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :twitter, ENV["TWITTER_API_KEY"], ENV["TWITTER_SECRET_KEY"], scope: 'user,public_repo'
+  config.omniauth :twitter, ENV["TWITTER_API_KEY"], ENV["TWITTER_SECRET_KEY"], scope: "user, public_repo"
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -78,3 +78,4 @@ ja:
       create: "登録に成功しました。"
       update: "内容が更新されました。"
       destroy: "登録内容が削除されました。"
+      destroy_omniauth: "アカウント連携が解除されました。"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       get :search
     end
   end
-  devise_for :users, controllers: { 
+  devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks",
     registrations: "users/registrations"
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,7 @@ Rails.application.routes.draw do
       get :search
     end
   end
-  devise_for :users
+  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
   resources :users, only: [:index, :show] do
     member do
       get :following, :followers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,10 @@ Rails.application.routes.draw do
       get :search
     end
   end
-  devise_for :users, controllers: { omniauth_callbacks: "users/omniauth_callbacks" }
+  devise_for :users, controllers: { 
+    omniauth_callbacks: "users/omniauth_callbacks",
+    registrations: "users/registrations"
+  }
   resources :users, only: [:index, :show] do
     member do
       get :following, :followers

--- a/db/migrate/20191020032413_add_columns_to_users.rb
+++ b/db/migrate/20191020032413_add_columns_to_users.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddColumnsToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :provider, :string
+    add_column :users, :uid, :string
+  end
+end

--- a/db/migrate/20191020042320_add_index_to_users.rb
+++ b/db/migrate/20191020042320_add_index_to_users.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_index :users, [:provider, :uid], unique: true
+  end
+end

--- a/db/migrate/20191020042320_add_index_to_users.rb
+++ b/db/migrate/20191020042320_add_index_to_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddIndexToUsers < ActiveRecord::Migration[5.2]
   def change
     add_index :users, [:provider, :uid], unique: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +13,6 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_10_20_042320) do
-
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -81,5 +82,4 @@ ActiveRecord::Schema.define(version: 2019_10_20_042320) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_10_14_083644) do
+ActiveRecord::Schema.define(version: 2019_10_20_042320) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -75,8 +74,12 @@ ActiveRecord::Schema.define(version: 2019_10_14_083644) do
     t.integer "men_num"
     t.integer "women_num"
     t.string "genre", default: "", null: false
+    t.string "provider"
+    t.string "uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["login_name"], name: "index_users_on_login_name", unique: true
+    t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
 end


### PR DESCRIPTION
- パスワードなしでユーザー情報更新可能に変更
- 新規ユーザー、既存ユーザーに対してTwitterのOAuth認証機能を追加
  - API KEY は `dotenv-rails` を使って `.env` で管理（開発環境でも利用可能にするため）